### PR TITLE
bashrc gitのbash補完を有効化

### DIFF
--- a/home/.bashrc
+++ b/home/.bashrc
@@ -8,6 +8,9 @@
 alias ls='ls --color=auto'
 #PS1='[\u@\h \W]\$ '
 PS1='\e[32m\u@\h\e[m \e[33m\w\e[m\n$? > '
-
 # path
 export PATH=~/bin:$PATH
+# git-completion
+if [ -e /usr/share/git/completion/git-completion.bash ]; then
+    source /usr/share/git/completion/git-completion.bash
+fi


### PR DESCRIPTION
.bashrc
    `source /usr/share/git/completion/git-completion.bash`を追加した.
    但し,そのfileが存在する場合に限る.