### PR TITLE
git-pep8 引数を設定

### DIFF
--- a/home/bin/git-pep8
+++ b/home/bin/git-pep8
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ue
+
 git ls-files \
     | grep -E "*.py$" \
-    | xargs pep8
+    | xargs pep8 $@


### PR DESCRIPTION
bin/git-pep8
    引数をそのままpep8に渡すようにした.