### PR TITLE
git-pep8: pycodestyleに変更

### DIFF
--- a/home/bin/git-pep8
+++ b/home/bin/git-pep8
@@ -4,4 +4,4 @@ set -ue
 
 git ls-files \
     | grep -E "*.py$" \
-    | xargs pep8 $@
+    | xargs pycodestyle $@


### PR DESCRIPTION
git-pep8
    pep8からpycodestyleに変更した.
    pep8はpycodestyleに改名されていた.
    pep8の方はversion 1.7.0で更新が止まっている.