### PR TITLE
cleanの問題を修正

### DIFF
--- a/function.sh
+++ b/function.sh
@@ -88,8 +88,7 @@ clean_dotfiles(){
     for dir in $(dir_list | tac)
     do
         local destination=$(to_destination ${dir})
-        echo ${destination}
-        if [ -e ${destination} -a -z "$(ls -A ${destination})" ]; then
+        if [ -e ${destination} ]  && [ -z "$(ls -A ${destination})" ]; then
             execute rmdir -v ${destination}
         fi
     done


### PR DESCRIPTION
function.sh
    clean時に存在しないdirectoryにlsを行っていた問題を修正した.
        原因は"-a"がshort circuitでなかったため.
        &&に変更した.
    不要なechoを削除した.