### PR TITLE
to_unicode_code_point

### DIFF
--- a/home/bin/to_unicode_code_point
+++ b/home/bin/to_unicode_code_point
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+for string in "$@";
+do
+  echo -n "$string" \
+  | while read -N 1 c; \
+    do \
+      d=$(echo -n "$c" | iconv -t UCS-2BE | xxd -p); \
+      if [[ "$d" == "fffd" ]]; then \
+        echo -n "$c" \
+          | iconv -t UCS-4BE \
+          | xxd -p \
+          | xargs printf '\\U%s'; \
+      else \
+        printf '\\u%s' $d; \
+      fi; \
+    done && printf '\n'
+done


### PR DESCRIPTION
sample
```
> to_unicode_code_point 砹 鉭
\u7839
\u926d
```

from [Bash対応のUnicodeコードポイント表記を出力するシェル芸 - Ryoto's Blog](https://www.ryotosaito.com/blog/?p=384)