### PR TITLE
to_unicode_code_point: add pipe input

### DIFF
--- a/home/bin/to_unicode_code_point
+++ b/home/bin/to_unicode_code_point
@@ -3,7 +3,7 @@
 _to_unicode_code_point() {
   while IFS= read -r string;
   do
-    echo -n "$string" \
+    echo -e -n "$string" \
     | while read -N 1 c; \
       do \
         d=$(echo -n "$c" | iconv -t UCS-2BE | xxd -p); \

--- a/home/bin/to_unicode_code_point
+++ b/home/bin/to_unicode_code_point
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 _to_unicode_code_point() {
-  while read -r string;
+  while IFS= read -r string;
   do
     echo -n "$string" \
     | while read -N 1 c; \

--- a/home/bin/to_unicode_code_point
+++ b/home/bin/to_unicode_code_point
@@ -1,18 +1,29 @@
 #!/bin/bash
 
-for string in "$@";
-do
-  echo -n "$string" \
-  | while read -N 1 c; \
-    do \
-      d=$(echo -n "$c" | iconv -t UCS-2BE | xxd -p); \
-      if [[ "$d" == "fffd" ]]; then \
-        echo -n "$c" \
-          | iconv -t UCS-4BE \
-          | xxd -p \
-          | xargs printf '\\U%s'; \
-      else \
-        printf '\\u%s' $d; \
-      fi; \
-    done && printf '\n'
-done
+_to_unicode_code_point() {
+  while read -r string;
+  do
+    echo -n "$string" \
+    | while read -N 1 c; \
+      do \
+        d=$(echo -n "$c" | iconv -t UCS-2BE | xxd -p); \
+        if [[ "$d" == "fffd" ]]; then \
+          echo -n "$c" \
+            | iconv -t UCS-4BE \
+            | xxd -p \
+            | xargs printf '\\U%s'; \
+        else \
+          printf '\\u%s' $d; \
+        fi; \
+      done && printf '\n'
+  done
+}
+
+if [ -p /dev/stdin ]; then
+  cat -
+else
+  for string in "$@";
+  do
+    echo "$string"
+  done
+fi | _to_unicode_code_point


### PR DESCRIPTION
sample
```
> echo 砹 鉭 | to_unicode_code_point
\u7839\u0020\u926d
```