### PR TITLE
Use MSYSTEM to check whether MSYS or not

### DIFF
--- a/function.sh
+++ b/function.sh
@@ -8,7 +8,7 @@ root_directories(){
     # home
     target_list+=("home")
     # msys
-    if uname | grep MSYS > /dev/null; then
+    if [ -n "${MSYSTEM-}" ]; then
         target_list+=("msys")
     fi
     echo "${target_list[@]}" \


### PR DESCRIPTION
`uname` returns 'MSYS_NT-...' or 'MINGW32_NT-...' or 'MINGW64-NT-...'