### PR TITLE
Update .bashrc for WSL

### DIFF
--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -2,7 +2,5 @@
 # ~/.bash_profile
 #
 
-# path
-export PATH=~/bin:$PATH
-# bashrc
+# load .bashrc
 [[ -f ~/.bashrc ]] && . ~/.bashrc

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -11,7 +11,9 @@ alias ls='ls --color=auto'
 PS1='\e[32m\u@\h\e[m \e[33m\w\e[m\n$? > '
 
 # PATH
-export PATH=~/bin:$PATH
+if [[ -d "${HOME}/bin" && ! "$PATH" =~ .*"${HOME}/bin:".* ]]; then
+  export PATH=~/bin:$PATH
+fi
 
 # Python
 export PIPENV_VENV_IN_PROJECT=true

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -24,8 +24,10 @@ if [ -e /mnt/c/Windows/System32/wsl.exe ]; then
   export LANG=en_US.UTF-8
   # PATH
   export PATH=~/bin:$PATH
-  # Display
-  export DISPLAY=`hostname`.mshome.net:0
+  # DISPLAY
+  if [ ! -e /mnt/wslg ]; then
+    export DISPLAY=`hostname`.mshome.net:0
+  fi
 fi
 
 # IME: fcitx

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -22,6 +22,13 @@ bind '"\C-e": clear-screen'
 if [ -e /mnt/c/Windows/System32/wsl.exe ]; then
   # LANG
   export LANG=en_US.UTF-8
+  # PATH
+  if [ ! -d /usr/games ]; then
+    export PATH=${PATH/:\/usr\/games:/:}
+  fi
+  if [ ! -d /usr/local/games ]; then
+    export PATH=${PATH/:\/usr\/local\/games:/:}
+  fi
   # DISPLAY
   if [ ! -e /mnt/wslg ]; then
     export DISPLAY=`hostname`.mshome.net:0

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -22,8 +22,6 @@ bind '"\C-e": clear-screen'
 if [ -e /mnt/c/Windows/System32/wsl.exe ]; then
   # LANG
   export LANG=en_US.UTF-8
-  # PATH
-  export PATH=~/bin:$PATH
   # DISPLAY
   if [ ! -e /mnt/wslg ]; then
     export DISPLAY=`hostname`.mshome.net:0

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -54,7 +54,9 @@ if [ -e /mnt/c/Windows/System32/wsl.exe ]; then
   fi
   # DISPLAY
   if [ ! -e /mnt/wslg ]; then
-    export DISPLAY=`hostname`.mshome.net:0
+    display=$(hostname).mshome.net:0
+    export DISPLAY=$display
+    unset -v display
   fi
 fi
 

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -24,8 +24,7 @@ function remove_from_path() {
 }
 
 # PS1
-#PS1='[\u@\h \W]\$ '
-PS1='\e[32m\u@\h\e[m \e[33m\w\e[m\n$? > '
+PS1='\[\e[32m\u@\h\e[m\] \[\e[33m\w\e[m\]\n$? > '
 
 # PATH
 if [ -d "${HOME}/bin" ]; then

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -9,6 +9,10 @@ alias ls='ls --color=auto'
 # PS1
 #PS1='[\u@\h \W]\$ '
 PS1='\e[32m\u@\h\e[m \e[33m\w\e[m\n$? > '
+
+# PATH
+export PATH=~/bin:$PATH
+
 # Python
 export PIPENV_VENV_IN_PROJECT=true
 

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -35,10 +35,11 @@ if [ -e /mnt/c/Windows/System32/wsl.exe ]; then
   fi
 fi
 
-# IME: fcitx
-if [ -e /usr/bin/fcitx-autostart ]; then
+# IME: fcitx5
+if [ -e /usr/bin/fcitx5 ]; then
   export GTK_IM_MODULE=fcitx
   export QT_IM_MODULE=fcitx
   export XMODIFIERS=@im=fcitx
-  (fcitx-autostart >/dev/null 2>&1 &)
+  (! pgrep fcitx5 &>> /dev/null && \
+    fcitx5 --disable=wayland -d --verbose '*'=0 &>> /dev/null &)
 fi

--- a/home/.bashrc
+++ b/home/.bashrc
@@ -6,13 +6,30 @@
 [[ $- != *i* ]] && return
 
 alias ls='ls --color=auto'
+
+# Functions
+function prepend_path() {
+  if [[ ! ":$PATH:" =~ .*":$1:".* ]]; then
+    export PATH=$1:$PATH
+  fi
+}
+
+function remove_from_path() {
+  if [[ ":$PATH:" =~ .*":$1:".* ]]; then
+    export PATH=:${PATH}:
+    export PATH=${PATH/:$1:/:}
+    export PATH=${PATH#:}
+    export PATH=${PATH%:}
+  fi
+}
+
 # PS1
 #PS1='[\u@\h \W]\$ '
 PS1='\e[32m\u@\h\e[m \e[33m\w\e[m\n$? > '
 
 # PATH
-if [[ -d "${HOME}/bin" && ! "$PATH" =~ .*"${HOME}/bin:".* ]]; then
-  export PATH=~/bin:$PATH
+if [ -d "${HOME}/bin" ]; then
+  prepend_path "${HOME}/bin"
 fi
 
 # Python
@@ -30,10 +47,10 @@ if [ -e /mnt/c/Windows/System32/wsl.exe ]; then
   export LANG=en_US.UTF-8
   # PATH
   if [ ! -d /usr/games ]; then
-    export PATH=${PATH/:\/usr\/games:/:}
+    remove_from_path /usr/games
   fi
   if [ ! -d /usr/local/games ]; then
-    export PATH=${PATH/:\/usr\/local\/games:/:}
+    remove_from_path /usr/local/games
   fi
   # DISPLAY
   if [ ! -e /mnt/wslg ]; then
@@ -49,3 +66,7 @@ if [ -e /usr/bin/fcitx5 ]; then
   (! pgrep fcitx5 &>> /dev/null && \
     fcitx5 --disable=wayland -d --verbose '*'=0 &>> /dev/null &)
 fi
+
+# Unset Functions
+unset -f prepend_path
+unset -f remove_from_path


### PR DESCRIPTION
# Update .bashrc

Use default DISPLAY when WSLg exists.

Update Fictx to version 5.

PATH
- Add `${HOME}/bin` in `.bashrc` instead of `.bash_profile`.
- Add prepend_path() and remove_from_path().

Fix shellcheck errors.